### PR TITLE
install cron when using ubuntu:16.04 image

### DIFF
--- a/Dockerfile-php7
+++ b/Dockerfile-php7
@@ -18,6 +18,7 @@ RUN apt-get update -qq && apt-get install -y -qq\
   php-sqlite3 \
   php-apcu \
   libapache2-mod-php \
+  cron \
   postfix \
   sudo \
   rsync \


### PR DESCRIPTION
Cron is not installed by default on ubuntu:16.04 image. Install cron in Dockerfile using ubuntu:16.04.

See this issue: https://github.com/aegir-project/dockerfiles/issues/45